### PR TITLE
Time zone provider

### DIFF
--- a/example/example.dart
+++ b/example/example.dart
@@ -9,10 +9,10 @@ import 'package:time_machine/time_machine_text_patterns.dart';
 Future main() async {
   try {
     // Sets up timezone and culture information
-    await TimeMachine.initialize();
+    await TimeMachine.initialize({'rootBundle': ''});
     print('Hello, ${DateTimeZone.local} from the Dart Time Machine!\n');
 
-    var tzdb = await DateTimeZoneProviders.tzdb;
+    var tzdb = await DateTimeZoneProviders.timezone;
     var paris = await tzdb['Europe/Paris'];
 
     var now = Instant.now();
@@ -24,27 +24,27 @@ Future main() async {
 
     print('Formatted');
     print('UTC Time: ${now.toString('dddd yyyy-MM-dd HH:mm')}');
-    print('Local Time: ${now.inLocalZone().toString('dddd yyyy-MM-dd HH:mm')}\n');
+    print(
+        'Local Time: ${now.inLocalZone().toString('dddd yyyy-MM-dd HH:mm')}\n');
 
     var french = (await Cultures.getCulture('fr-FR'))!;
     print('Formatted and French ($french)');
     print('UTC Time: ${now.toString('dddd yyyy-MM-dd HH:mm', french)}');
-    print('Local Time: ${now.inLocalZone().toString('dddd yyyy-MM-dd HH:mm', french)}\n');
+    print(
+        'Local Time: ${now.inLocalZone().toString('dddd yyyy-MM-dd HH:mm', french)}\n');
 
     print('Parse French Formatted ZonedDateTime');
 
     // without the 'z' parsing will be forced to interpret the timezone as UTC
-    var localText = now
-        .inLocalZone()
-        .toString('dddd yyyy-MM-dd HH:mm z', french);
+    var localText =
+        now.inLocalZone().toString('dddd yyyy-MM-dd HH:mm z', french);
 
-    var localClone = ZonedDateTimePattern
-        .createWithCulture('dddd yyyy-MM-dd HH:mm z', french)
+    var localClone = ZonedDateTimePattern.createWithCulture(
+            'dddd yyyy-MM-dd HH:mm z', french)
         .parse(localText);
 
     print(localClone.value);
-  }
-  catch (error, stack) {
+  } catch (error, stack) {
     print(error);
     print(stack);
   }

--- a/example/flutter_example/pubspec.yaml
+++ b/example/flutter_example/pubspec.yaml
@@ -1,6 +1,9 @@
 name: time_machine_test_app
 description: A new Flutter application.
 
+environment:
+  sdk: '^3.5.0'
+
 dependencies:
   flutter:
     sdk: flutter

--- a/lib/src/platforms/dart_flutter.dart
+++ b/lib/src/platforms/dart_flutter.dart
@@ -1,0 +1,1 @@
+const kIsPureDart = false;

--- a/lib/src/platforms/dart_pure.dart
+++ b/lib/src/platforms/dart_pure.dart
@@ -1,0 +1,1 @@
+const kIsPureDart = true;

--- a/lib/src/platforms/vm.dart
+++ b/lib/src/platforms/vm.dart
@@ -8,10 +8,13 @@ import 'dart:convert';
 import 'dart:io' as io;
 
 import 'dart:typed_data';
+import 'package:time_machine/src/platforms/dart_pure.dart';
 import 'package:time_machine/src/time_machine_internal.dart';
 
 import 'platform_io.dart';
 import 'dart:isolate' show Isolate;
+
+export 'dart_pure.dart' if (dart.library.ui) 'dart_flutter.dart';
 
 class _VirtualMachineIO implements PlatformIO {
   @override
@@ -63,13 +66,7 @@ Future initialize(Map args, {testing = false}) {
   String? cultureOverride = args['culture'];
   final testing = args['testing'] ?? false;
 
-  if (!testing &&
-      (io.Platform.isIOS ||
-          io.Platform.isAndroid ||
-          io.Platform.isFuchsia ||
-          io.Platform.isMacOS ||
-          io.Platform.isWindows ||
-          io.Platform.isLinux)) {
+  if (!testing && !kIsPureDart) {
     if (args['rootBundle'] == null) {
       throw Exception(
           "Pass in the rootBundle from 'package:flutter/services.dart';");
@@ -97,7 +94,7 @@ class TimeMachine {
     ICultures.loadAllCulturesInformation_SetFlag();
 
     // Default provider
-    var tzdb = await DateTimeZoneProviders.tzdb;
+    var tzdb = await DateTimeZoneProviders.timezone;
     IDateTimeZoneProviders.defaultProvider = tzdb;
 
     // Default TimeZone

--- a/lib/src/timezones/time_zone_datetimezone_source.dart
+++ b/lib/src/timezones/time_zone_datetimezone_source.dart
@@ -1,0 +1,82 @@
+import 'package:timezone/data/latest.dart' as tz;
+import 'package:timezone/timezone.dart' as tz;
+import 'package:time_machine/src/time_machine_internal.dart';
+
+class TimeZoneDateTimeZoneSource extends DateTimeZoneSource {
+  static bool _initialized = false;
+
+  static Future _init() async {
+    if (!_initialized) {
+      tz.initializeTimeZones();
+      _initialized = true;
+    }
+  }
+
+  @override
+  Future<DateTimeZone> forId(String id) async {
+    await _init();
+
+    return forCachedId(id);
+  }
+
+  @override
+  DateTimeZone forCachedId(String id) {
+    final location = tz.getLocation(id);
+
+    final zoneIntervals = List<ZoneInterval>.empty(growable: true);
+
+    // if we don't have any transitions, use the default zone as the only zone
+    if (location.transitionAt.isEmpty) {
+      final firstInterval = IZoneInterval.newZoneInterval(
+        location.zones.first.abbreviation,
+        IInstant.beforeMinValue,
+        IInstant.afterMaxValue,
+        Offset(location.zones.first.offset ~/ 1000),
+        Offset(
+          location.zones.first.offset ~/ 1000 +
+              (location.zones.first.isDst ? 3600 : 0),
+        ),
+      );
+
+      zoneIntervals.add(firstInterval);
+    }
+
+    for (var i = 0; i < location.transitionAt.length; i++) {
+      var zoneStart = location.transitionAt[i];
+      var zoneEnd = location.transitionAt.length > i + 1
+          ? location.transitionAt[i + 1]
+          : null;
+
+      final zone = location.zones[location.transitionZone[i]];
+
+      final zoneInterval = IZoneInterval.newZoneInterval(
+        zone.abbreviation,
+        Instant.fromEpochMilliseconds(zoneStart),
+        zoneEnd != null ? Instant.fromEpochMilliseconds(zoneEnd) : null,
+        Offset(zone.offset ~/ 1000),
+        Offset(
+          zone.offset ~/ 1000 + (zone.isDst ? 3600 : 0),
+        ),
+      );
+
+      zoneIntervals.add(zoneInterval);
+    }
+
+    final precalculatedZone =
+        PrecalculatedDateTimeZone(id, zoneIntervals, null);
+
+    return precalculatedZone;
+  }
+
+  @override
+  Future<Iterable<String>> getIds() async {
+    await _init();
+    return tz.timeZoneDatabase.locations.keys;
+  }
+
+  @override
+  String get systemDefaultId => tz.local.name;
+
+  @override
+  Future<String> get versionId => Future.sync(() => 'TZDB: 2024a');
+}

--- a/lib/src/timezones/time_zone_datetimezone_source.dart
+++ b/lib/src/timezones/time_zone_datetimezone_source.dart
@@ -75,7 +75,7 @@ class TimeZoneDateTimeZoneSource extends DateTimeZoneSource {
   }
 
   @override
-  String get systemDefaultId => tz.local.name;
+  String get systemDefaultId => TzdbIndex.localId;
 
   @override
   Future<String> get versionId => Future.sync(() => 'TZDB: 2024a');

--- a/lib/src/timezones/tzdb_datetimezone_source.dart
+++ b/lib/src/timezones/tzdb_datetimezone_source.dart
@@ -7,23 +7,30 @@ import 'dart:async';
 import 'package:time_machine/src/time_machine_internal.dart';
 import 'package:time_machine/src/timezones/time_machine_timezones.dart';
 
+import 'time_zone_datetimezone_source.dart';
+
 // todo: the Internal Classes here make me sad
 
 @internal
 abstract class IDateTimeZoneProviders {
-  static set defaultProvider(DateTimeZoneProvider provider) => DateTimeZoneProviders._defaultProvider = provider;
+  static set defaultProvider(DateTimeZoneProvider provider) =>
+      DateTimeZoneProviders._defaultProvider = provider;
 }
-
 
 // todo: I think we need an easy way for library users to inject their own IDateTimeZoneSource
 abstract class DateTimeZoneProviders {
   // todo: await ... await ... patterns are so ick.
 
   static Future<DateTimeZoneProvider>? _tzdb;
+  static Future<DateTimeZoneProvider>? _timezone;
 
-  static Future<DateTimeZoneProvider> get tzdb => _tzdb ??= DateTimeZoneCache.getCache(TzdbDateTimeZoneSource());
+  static Future<DateTimeZoneProvider> get tzdb =>
+      _tzdb ??= DateTimeZoneCache.getCache(TzdbDateTimeZoneSource());
+  static Future<DateTimeZoneProvider> get timezone =>
+      _timezone ??= DateTimeZoneCache.getCache(TimeZoneDateTimeZoneSource());
 
   static DateTimeZoneProvider? _defaultProvider;
+
   /// This is the default [DateTimeZoneProvider] for the currently loaded TimeMachine.
   /// It will be used internally where-ever timezone support is needed when no provider is provided,
   static DateTimeZoneProvider? get defaultProvider => _defaultProvider;
@@ -32,7 +39,9 @@ abstract class DateTimeZoneProviders {
 @internal
 class ITzdbDateTimeZoneSource {
   static void loadAllTimeZoneInformation_SetFlag() {
-    if (TzdbDateTimeZoneSource._cachedTzdbIndex != null) throw StateError('loadAllTimeZone flag may not be set after TZDB is initalized.');
+    if (TzdbDateTimeZoneSource._cachedTzdbIndex != null)
+      throw StateError(
+          'loadAllTimeZone flag may not be set after TZDB is initalized.');
     TzdbDateTimeZoneSource._loadAllTimeZoneInformation = true;
   }
 }
@@ -47,8 +56,7 @@ class TzdbDateTimeZoneSource extends DateTimeZoneSource {
 
     if (_loadAllTimeZoneInformation) {
       _cachedTzdbIndex = await TzdbIndex.loadAll();
-    }
-    else {
+    } else {
       _cachedTzdbIndex = await TzdbIndex.load();
     }
 
@@ -68,7 +76,8 @@ class TzdbDateTimeZoneSource extends DateTimeZoneSource {
       : _init().then((_) => _cachedTzdbIndex!);
 
   @override
-  Future<DateTimeZone> forId(String id) async => (await _tzdbIndexAsync).getTimeZone(id);
+  Future<DateTimeZone> forId(String id) async =>
+      (await _tzdbIndexAsync).getTimeZone(id);
 
   @override
   DateTimeZone forCachedId(String id) => _cachedTzdbIndex!.getTimeZoneSync(id)!;
@@ -83,4 +92,3 @@ class TzdbDateTimeZoneSource extends DateTimeZoneSource {
   @override
   Future<String> get versionId => Future.sync(() => 'TZDB: 2018');
 }
-

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,37 +1,28 @@
 name: time_machine
-description: Date and time library for Flutter, Web, and Server with support for timezones, calendars, cultures, formatting and parsing.
+description: Date and time library for Flutter, Web, and Server with support for
+  timezones, calendars, cultures, formatting and parsing.
 version: 0.9.17
 homepage: https://github.com/Dana-Ferguson/time_machine
 
 # SDK's lower bound must be compatible with the current version pushed with Flutter
 # ./flutter --version
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.12.0 <4.0.0"
 
 # Verify flutter_test dependency compatibility first before updating any constraints
 # https://github.com/flutter/flutter/blob/master/packages/flutter_test/pubspec.yaml
 dependencies:
-  meta: "^1.3.0"
-#  quiver_hashcode: "^1.0.0"
-#  collection: "^1.14.10"
-  collection: "^1.15.0"
-#  resource: "^2.1.6"
-#  flutter:
-#    sdk: flutter
+  collection: ^1.19.1
+  meta: ^1.16.0
+  timezone: ^0.10.0
 
 dev_dependencies:
-  test: "^1.16.8"
-  matcher: "^0.12.10"
-  pedantic: "^1.11.0"
+  archive: ^4.0.2
   args: ^2.0.0
-  archive: ^3.1.2
   # used for the TzdbCompiler
-  http: "^0.13.1"
+  http: ^1.2.2
+  matcher: "^0.12.10"
   path: "^1.8.0"
-  xml: "^5.0.2"
-
-# Flutter Testing
-#  test: "^0.12.3"
-#  matcher: "^0.12.2+1"
-#  flutter_test:
-#    sdk: flutter
+  pedantic: "^1.11.0"
+  test: "^1.16.8"
+  xml: ^6.5.0

--- a/test/datetimezone_local_conversions_test.dart
+++ b/test/datetimezone_local_conversions_test.dart
@@ -42,75 +42,91 @@ Future setup() async {
 
 /// Local midnight at the start of the transition (June 1st) becomes 1am.
 final DateTimeZone TransitionForwardAtMidnightZone =
-SingleTransitionDateTimeZone(Instant.utc(2000, 6, 1, 2, 0), Offset.hours(-2), Offset.hours(-1));
+    SingleTransitionDateTimeZone(
+        Instant.utc(2000, 6, 1, 2, 0), Offset.hours(-2), Offset.hours(-1));
 
 /// Local 1am at the start of the transition (June 1st) becomes midnight.
 final DateTimeZone TransitionBackwardToMidnightZone =
-SingleTransitionDateTimeZone(Instant.utc(2000, 6, 1, 3, 0), Offset.hours(-2), Offset.hours(-3));
+    SingleTransitionDateTimeZone(
+        Instant.utc(2000, 6, 1, 3, 0), Offset.hours(-2), Offset.hours(-3));
 
 /// Local 11.20pm at the start of the transition (May 30th) becomes 12.20am of June 1st.
 final DateTimeZone TransitionForwardBeforeMidnightZone =
-SingleTransitionDateTimeZone(Instant.utc(2000, 6, 1, 1, 20), Offset.hours(-2), Offset.hours(-1));
+    SingleTransitionDateTimeZone(
+        Instant.utc(2000, 6, 1, 1, 20), Offset.hours(-2), Offset.hours(-1));
 
 /// Local 12.20am at the start of the transition (June 1st) becomes 11.20pm of the previous day.
 final DateTimeZone TransitionBackwardAfterMidnightZone =
-SingleTransitionDateTimeZone(Instant.utc(2000, 6, 1, 2, 20), Offset.hours(-2), Offset.hours(-3));
+    SingleTransitionDateTimeZone(
+        Instant.utc(2000, 6, 1, 2, 20), Offset.hours(-2), Offset.hours(-3));
 
 final LocalDate TransitionDate = LocalDate(2000, 6, 1);
 
 @Test()
-void AmbiguousStartOfDay_TransitionAtMidnight()
-{
+void AmbiguousStartOfDay_TransitionAtMidnight() {
   // Occurrence before transition
-  var expected = IZonedDateTime.trusted(LocalDateTime(2000, 6, 1, 0, 0, 0).withOffset(Offset.hours(-2)),
+  var expected = IZonedDateTime.trusted(
+      LocalDateTime(2000, 6, 1, 0, 0, 0).withOffset(Offset.hours(-2)),
       TransitionBackwardToMidnightZone);
-  var actual = ZonedDateTime.atStartOfDay(TransitionDate, TransitionBackwardToMidnightZone);
+  var actual = ZonedDateTime.atStartOfDay(
+      TransitionDate, TransitionBackwardToMidnightZone);
   expect(expected, actual);
-  expect(expected, TransitionDate.atStartOfDayInZone(TransitionBackwardToMidnightZone));
+  expect(expected,
+      TransitionDate.atStartOfDayInZone(TransitionBackwardToMidnightZone));
 }
 
 @Test()
-void AmbiguousStartOfDay_TransitionAfterMidnight()
-{
+void AmbiguousStartOfDay_TransitionAfterMidnight() {
   // Occurrence before transition
-  var expected = IZonedDateTime.trusted(LocalDateTime(2000, 6, 1, 0, 0, 0).withOffset(Offset.hours(-2)),
+  var expected = IZonedDateTime.trusted(
+      LocalDateTime(2000, 6, 1, 0, 0, 0).withOffset(Offset.hours(-2)),
       TransitionBackwardAfterMidnightZone);
-  var actual = ZonedDateTime.atStartOfDay(TransitionDate, TransitionBackwardAfterMidnightZone);
+  var actual = ZonedDateTime.atStartOfDay(
+      TransitionDate, TransitionBackwardAfterMidnightZone);
   expect(expected, actual);
-  expect(expected, TransitionDate.atStartOfDayInZone(TransitionBackwardAfterMidnightZone));
+  expect(expected,
+      TransitionDate.atStartOfDayInZone(TransitionBackwardAfterMidnightZone));
 }
 
 @Test()
-void SkippedStartOfDay_TransitionAtMidnight()
-{
+void SkippedStartOfDay_TransitionAtMidnight() {
   // 1am because of the skip
-  var expected = IZonedDateTime.trusted(LocalDateTime(2000, 6, 1, 1, 0, 0).withOffset(Offset.hours(-1)),
+  var expected = IZonedDateTime.trusted(
+      LocalDateTime(2000, 6, 1, 1, 0, 0).withOffset(Offset.hours(-1)),
       TransitionForwardAtMidnightZone);
-  var actual = ZonedDateTime.atStartOfDay(TransitionDate, TransitionForwardAtMidnightZone);
+  var actual = ZonedDateTime.atStartOfDay(
+      TransitionDate, TransitionForwardAtMidnightZone);
   expect(expected, actual);
-  expect(expected, TransitionDate.atStartOfDayInZone(TransitionForwardAtMidnightZone));
+  expect(expected,
+      TransitionDate.atStartOfDayInZone(TransitionForwardAtMidnightZone));
 }
 
 @Test()
-void SkippedStartOfDay_TransitionBeforeMidnight()
-{
+void SkippedStartOfDay_TransitionBeforeMidnight() {
   // 12.20am because of the skip
-  var expected = IZonedDateTime.trusted(LocalDateTime(2000, 6, 1, 0, 20, 0).withOffset(Offset.hours(-1)),
+  var expected = IZonedDateTime.trusted(
+      LocalDateTime(2000, 6, 1, 0, 20, 0).withOffset(Offset.hours(-1)),
       TransitionForwardBeforeMidnightZone);
-  var actual = ZonedDateTime.atStartOfDay(TransitionDate, TransitionForwardBeforeMidnightZone);
+  var actual = ZonedDateTime.atStartOfDay(
+      TransitionDate, TransitionForwardBeforeMidnightZone);
   expect(expected, actual);
-  expect(expected, TransitionDate.atStartOfDayInZone(TransitionForwardBeforeMidnightZone));
+  expect(expected,
+      TransitionDate.atStartOfDayInZone(TransitionForwardBeforeMidnightZone));
 }
 
 @Test()
-void UnambiguousStartOfDay()
-{
+void UnambiguousStartOfDay() {
   // Just a simple midnight in March.
-  var expected = IZonedDateTime.trusted(LocalDateTime(2000, 3, 1, 0, 0, 0).withOffset(Offset.hours(-2)),
+  var expected = IZonedDateTime.trusted(
+      LocalDateTime(2000, 3, 1, 0, 0, 0).withOffset(Offset.hours(-2)),
       TransitionForwardAtMidnightZone);
-  var actual = ZonedDateTime.atStartOfDay(LocalDate(2000, 3, 1), TransitionForwardAtMidnightZone);
+  var actual = ZonedDateTime.atStartOfDay(
+      LocalDate(2000, 3, 1), TransitionForwardAtMidnightZone);
   expect(expected, actual);
-  expect(expected, LocalDate(2000, 3, 1).atStartOfDayInZone(TransitionForwardAtMidnightZone));
+  expect(
+      expected,
+      LocalDate(2000, 3, 1)
+          .atStartOfDayInZone(TransitionForwardAtMidnightZone));
 }
 
 T? captureVM<T extends Error>(Function() action) {
@@ -118,7 +134,8 @@ T? captureVM<T extends Error>(Function() action) {
     action();
   } on T catch (error) {
     return error;
-  };
+  }
+  ;
 
   return null;
 }
@@ -129,34 +146,37 @@ Object? capture(Function() action) {
     action();
   } catch (error) {
     return error;
-  };
+  }
+  ;
 
   return null;
 }
 
-void AssertImpossible(LocalDateTime localTime, DateTimeZone zone)
-{
+void AssertImpossible(LocalDateTime localTime, DateTimeZone zone) {
   var mapping = zone.mapLocal(localTime);
   expect(0, mapping.count);
 
-  SkippedTimeError e; // = Assert.Throws<SkippedTimeException>(() => mapping.Single());
-  expect(e = (capture(() => mapping.single())) as SkippedTimeError, const TypeMatcher<SkippedTimeError>());
+  SkippedTimeError
+      e; // = Assert.Throws<SkippedTimeException>(() => mapping.Single());
+  expect(e = (capture(() => mapping.single())) as SkippedTimeError,
+      const TypeMatcher<SkippedTimeError>());
   expect(localTime, e.localDateTime);
   expect(zone, e.zone);
 
   // e = Assert.Throws<SkippedTimeException>(() => mapping.First());
-  expect(e = (capture(() => mapping.first())) as SkippedTimeError, const TypeMatcher<SkippedTimeError>());
+  expect(e = (capture(() => mapping.first())) as SkippedTimeError,
+      const TypeMatcher<SkippedTimeError>());
   expect(localTime, e.localDateTime);
   expect(zone, e.zone);
 
   // e = Assert.Throws<SkippedTimeException>(() => mapping.Last());
-  expect(e = (capture(() => mapping.last())) as SkippedTimeError, const TypeMatcher<SkippedTimeError>());
+  expect(e = (capture(() => mapping.last())) as SkippedTimeError,
+      const TypeMatcher<SkippedTimeError>());
   expect(localTime, e.localDateTime);
   expect(zone, e.zone);
 }
 
-void AssertAmbiguous(LocalDateTime localTime, DateTimeZone zone)
-{
+void AssertAmbiguous(LocalDateTime localTime, DateTimeZone zone) {
   ZonedDateTime earlier = zone.mapLocal(localTime).first();
   ZonedDateTime later = zone.mapLocal(localTime).last();
   expect(localTime, earlier.localDateTime);
@@ -165,8 +185,10 @@ void AssertAmbiguous(LocalDateTime localTime, DateTimeZone zone)
 
   var mapping = zone.mapLocal(localTime);
   expect(2, mapping.count);
-  AmbiguousTimeError e; // = Assert.Throws<AmbiguousTimeException>(() => mapping.Single());
-  expect(e = (capture(() => mapping.single())) as AmbiguousTimeError, const TypeMatcher<AmbiguousTimeError>());
+  AmbiguousTimeError
+      e; // = Assert.Throws<AmbiguousTimeException>(() => mapping.Single());
+  expect(e = (capture(() => mapping.single())) as AmbiguousTimeError,
+      const TypeMatcher<AmbiguousTimeError>());
   expect(localTime, e.localDateTime);
   expect(zone, e.Zone);
   expect(earlier, e.earlierMapping);
@@ -176,21 +198,21 @@ void AssertAmbiguous(LocalDateTime localTime, DateTimeZone zone)
   expect(later, mapping.last());
 }
 
-void AssertOffset(int expectedHours, LocalDateTime localTime, DateTimeZone zone)
-{
+void AssertOffset(
+    int expectedHours, LocalDateTime localTime, DateTimeZone zone) {
   var mapping = zone.mapLocal(localTime);
   expect(1, mapping.count);
   var zoned = mapping.single();
   expect(zoned, mapping.first());
   expect(zoned, mapping.last());
-  int actualHours = zoned.offset.inMilliseconds ~/ TimeConstants.millisecondsPerHour;
+  int actualHours =
+      zoned.offset.inMilliseconds ~/ TimeConstants.millisecondsPerHour;
   expect(expectedHours, actualHours);
 }
 
 // Los Angeles goes from -7 to -8 on November 7th 2010 at 2am wall time
 @Test()
-void GetOffsetFromLocal_LosAngelesFallTransition()
-{
+void GetOffsetFromLocal_LosAngelesFallTransition() {
   var before = LocalDateTime(2010, 11, 7, 0, 30, 0);
   var atTransition = LocalDateTime(2010, 11, 7, 1, 0, 0);
   var ambiguous = LocalDateTime(2010, 11, 7, 1, 30, 0);
@@ -202,8 +224,7 @@ void GetOffsetFromLocal_LosAngelesFallTransition()
 }
 
 @Test()
-void GetOffsetFromLocal_LosAngelesSpringTransition()
-{
+void GetOffsetFromLocal_LosAngelesSpringTransition() {
   var before = LocalDateTime(2010, 3, 14, 1, 30, 0);
   var impossible = LocalDateTime(2010, 3, 14, 2, 30, 0);
   var atTransition = LocalDateTime(2010, 3, 14, 3, 0, 0);
@@ -216,8 +237,7 @@ void GetOffsetFromLocal_LosAngelesSpringTransition()
 
 // New Zealand goes from +13 to +12 on April 4th 2010 at 3am wall time
 @Test()
-void GetOffsetFromLocal_NewZealandFallTransition()
-{
+void GetOffsetFromLocal_NewZealandFallTransition() {
   var before = LocalDateTime(2010, 4, 4, 1, 30, 0);
   var atTransition = LocalDateTime(2010, 4, 4, 2, 0, 0);
   var ambiguous = LocalDateTime(2010, 4, 4, 2, 30, 0);
@@ -230,8 +250,7 @@ void GetOffsetFromLocal_NewZealandFallTransition()
 
 // New Zealand goes from +12 to +13 on September 26th 2010 at 2am wall time
 @Test()
-void GetOffsetFromLocal_NewZealandSpringTransition()
-{
+void GetOffsetFromLocal_NewZealandSpringTransition() {
   var before = LocalDateTime(2010, 9, 26, 1, 30, 0);
   var impossible = LocalDateTime(2010, 9, 26, 2, 30, 0);
   var atTransition = LocalDateTime(2010, 9, 26, 3, 0, 0);
@@ -244,8 +263,7 @@ void GetOffsetFromLocal_NewZealandSpringTransition()
 
 // Paris goes from +1 to +2 on March 28th 2010 at 2am wall time
 @Test()
-void GetOffsetFromLocal_ParisFallTransition()
-{
+void GetOffsetFromLocal_ParisFallTransition() {
   var before = LocalDateTime(2010, 10, 31, 1, 30, 0);
   var atTransition = LocalDateTime(2010, 10, 31, 2, 0, 0);
   var ambiguous = LocalDateTime(2010, 10, 31, 2, 30, 0);
@@ -257,8 +275,7 @@ void GetOffsetFromLocal_ParisFallTransition()
 }
 
 @Test()
-void GetOffsetFromLocal_ParisSpringTransition()
-{
+void GetOffsetFromLocal_ParisSpringTransition() {
   var before = LocalDateTime(2010, 3, 28, 1, 30, 0);
   var impossible = LocalDateTime(2010, 3, 28, 2, 30, 0);
   var atTransition = LocalDateTime(2010, 3, 28, 3, 0, 0);
@@ -270,8 +287,7 @@ void GetOffsetFromLocal_ParisSpringTransition()
 }
 
 @Test()
-void MapLocalDateTime_UnambiguousDateReturnsUnambiguousMapping()
-{
+void MapLocalDateTime_UnambiguousDateReturnsUnambiguousMapping() {
   //2011-11-09 01:30:00 - not ambiguous in America/New York timezone
   var unambigiousTime = LocalDateTime(2011, 11, 9, 1, 30, 0);
   var mapping = NewYork.mapLocal(unambigiousTime);
@@ -279,8 +295,7 @@ void MapLocalDateTime_UnambiguousDateReturnsUnambiguousMapping()
 }
 
 @Test()
-void MapLocalDateTime_AmbiguousDateReturnsAmbigousMapping()
-{
+void MapLocalDateTime_AmbiguousDateReturnsAmbigousMapping() {
   //2011-11-06 01:30:00 - falls during DST - EST conversion in America/New York timezone
   var ambiguousTime = LocalDateTime(2011, 11, 6, 1, 30, 0);
   var mapping = NewYork.mapLocal(ambiguousTime);
@@ -288,8 +303,7 @@ void MapLocalDateTime_AmbiguousDateReturnsAmbigousMapping()
 }
 
 @Test()
-void MapLocalDateTime_SkippedDateReturnsSkippedMapping()
-{
+void MapLocalDateTime_SkippedDateReturnsSkippedMapping() {
   //2011-03-13 02:30:00 - falls during EST - DST conversion in America/New York timezone
   var skippedTime = LocalDateTime(2011, 3, 13, 2, 30, 0);
   var mapping = NewYork.mapLocal(skippedTime);
@@ -304,19 +318,22 @@ void MapLocalDateTime_SkippedDateReturnsSkippedMapping()
 @TestCase(['Pacific/Enderbury', "1994-12-31"])
 @TestCase(['Pacific/Kiritimati', "1994-12-31"])
 @TestCase(['Pacific/Kwajalein', "1993-08-21"])
-Future AtStartOfDay_DayDoesntExist(String zoneId, String localDate) async
-{
+Future AtStartOfDay_DayDoesntExist(String zoneId, String localDate) async {
   LocalDate badDate = LocalDatePattern.iso.parse(localDate).value;
-  DateTimeZone zone = await (await DateTimeZoneProviders.tzdb)[zoneId];
-  SkippedTimeError exception; //  = Assert.Throws<SkippedTimeException>(() => zone.AtStartOfDay(badDate));
-  expect(exception = (capture(() => ZonedDateTime.atStartOfDay(badDate, zone))) as SkippedTimeError, const TypeMatcher<SkippedTimeError>());
+  DateTimeZone zone = await (await DateTimeZoneProviders.timezone)[zoneId];
+  SkippedTimeError
+      exception; //  = Assert.Throws<SkippedTimeException>(() => zone.AtStartOfDay(badDate));
+  expect(
+      exception = (capture(() => ZonedDateTime.atStartOfDay(badDate, zone)))
+          as SkippedTimeError,
+      const TypeMatcher<SkippedTimeError>());
   expect(badDate.at(LocalTime.midnight), exception.localDateTime);
 }
 
 @Test()
-void AtStrictly_InWinter()
-{
-  var when = ZonedDateTime.atStrictly(LocalDateTime(2009, 12, 22, 21, 39, 30), Pacific);
+void AtStrictly_InWinter() {
+  var when = ZonedDateTime.atStrictly(
+      LocalDateTime(2009, 12, 22, 21, 39, 30), Pacific);
 
   expect(2009, when.year);
   expect(12, when.monthOfYear);
@@ -329,9 +346,9 @@ void AtStrictly_InWinter()
 }
 
 @Test()
-void AtStrictly_InSummer()
-{
-  var when = ZonedDateTime.atStrictly(LocalDateTime(2009, 6, 22, 21, 39, 30), Pacific);
+void AtStrictly_InSummer() {
+  var when =
+      ZonedDateTime.atStrictly(LocalDateTime(2009, 6, 22, 21, 39, 30), Pacific);
 
   expect(2009, when.year);
   expect(6, when.monthOfYear);
@@ -345,26 +362,29 @@ void AtStrictly_InSummer()
 /// Pacific time changed from -7 to -8 at 2am wall time on November 2nd 2009,
 /// so 2am became 1am.
 @Test()
-void AtStrictly_ThrowsWhenAmbiguous()
-{
+void AtStrictly_ThrowsWhenAmbiguous() {
   // Assert.Throws<AmbiguousTimeException>(() => Pacific.AtStrictly(new LocalDateTime.fromYMDHMS(2009, 11, 1, 1, 30, 0)));
-  expect(() => ZonedDateTime.atStrictly(LocalDateTime(2009, 11, 1, 1, 30, 0), Pacific), willThrow<AmbiguousTimeError>());
+  expect(
+      () => ZonedDateTime.atStrictly(
+          LocalDateTime(2009, 11, 1, 1, 30, 0), Pacific),
+      willThrow<AmbiguousTimeError>());
 }
 
 /// Pacific time changed from -8 to -7 at 2am wall time on March 8th 2009,
 /// so 2am became 3am. This means that 2.30am doesn't exist on that day.
 @Test()
-void AtStrictly_ThrowsWhenSkipped()
-{
+void AtStrictly_ThrowsWhenSkipped() {
   // Assert.Throws<SkippedTimeException>(() => Pacific.AtStrictly(new LocalDateTime.fromYMDHMS(2009, 3, 8, 2, 30, 0)));
-  expect(() => ZonedDateTime.atStrictly(LocalDateTime(2009, 3, 8, 2, 30, 0), Pacific), willThrow<SkippedTimeError>());
+  expect(
+      () => ZonedDateTime.atStrictly(
+          LocalDateTime(2009, 3, 8, 2, 30, 0), Pacific),
+      willThrow<SkippedTimeError>());
 }
 
 /// Pacific time changed from -7 to -8 at 2am wall time on November 2nd 2009,
 /// so 2am became 1am. We'll return the earlier result, i.e. with the offset of -7
 @Test()
-void AtLeniently_AmbiguousTime_ReturnsEarlierMapping()
-{
+void AtLeniently_AmbiguousTime_ReturnsEarlierMapping() {
   var local = LocalDateTime(2009, 11, 1, 1, 30, 0);
   var zoned = ZonedDateTime.atLeniently(local, Pacific);
   expect(zoned.localDateTime, local);
@@ -375,8 +395,7 @@ void AtLeniently_AmbiguousTime_ReturnsEarlierMapping()
 /// so 2am became 3am. This means that 2:30am doesn't exist on that day.
 /// We'll return 3:30am, the forward-shifted value.
 @Test()
-void AtLeniently_ReturnsForwardShiftedValue()
-{
+void AtLeniently_ReturnsForwardShiftedValue() {
   var local = LocalDateTime(2009, 3, 8, 2, 30, 0);
   var zoned = ZonedDateTime.atLeniently(local, Pacific);
   expect(LocalDateTime(2009, 3, 8, 3, 30, 0), zoned.localDateTime);
@@ -384,11 +403,12 @@ void AtLeniently_ReturnsForwardShiftedValue()
 }
 
 @Test()
-void ResolveLocal()
-{
+void ResolveLocal() {
   // Don't need much for this - it only delegates.
   var ambiguous = LocalDateTime(2009, 11, 1, 1, 30, 0);
   var skipped = LocalDateTime(2009, 3, 8, 2, 30, 0);
-  expect(ZonedDateTime.atLeniently(ambiguous, Pacific), ZonedDateTime.resolve(ambiguous, Pacific, Resolvers.lenientResolver));
-  expect(ZonedDateTime.atLeniently(skipped, Pacific), ZonedDateTime.resolve(skipped, Pacific, Resolvers.lenientResolver));
+  expect(ZonedDateTime.atLeniently(ambiguous, Pacific),
+      ZonedDateTime.resolve(ambiguous, Pacific, Resolvers.lenientResolver));
+  expect(ZonedDateTime.atLeniently(skipped, Pacific),
+      ZonedDateTime.resolve(skipped, Pacific, Resolvers.lenientResolver));
 }


### PR DESCRIPTION
This PR adds a `DateTimeZoneSource` based on the `timezone` package. This is the first in a serious of pull requests to update the original code base.

In order to not introduce a single, massive change, this fork shall be updated in incremental steps.

The next step will be to remove the original tzdb code, fix outdated Dart patterns, then re-introduce a native tzdb based on the `timezone` code.