### PR TITLE
Use native inclusion of culture data on native platforms

### DIFF
--- a/lib/src/platforms/vm.dart
+++ b/lib/src/platforms/vm.dart
@@ -8,7 +8,6 @@ import 'dart:convert';
 import 'dart:io' as io;
 
 import 'dart:typed_data';
-import 'package:time_machine2/src/platforms/dart_pure.dart';
 import 'package:time_machine2/src/time_machine_internal.dart';
 import 'package:time_machine2/src/timezones/datetimezone_providers.dart';
 import 'package:time_machine2/time_machine2.dart';
@@ -16,7 +15,7 @@ import 'package:time_machine2/time_machine2.dart';
 import 'platform_io.dart';
 import 'dart:isolate' show Isolate;
 
-export 'dart_pure.dart' if (dart.library.ui) 'dart_flutter.dart';
+import 'dart_pure.dart' if (dart.library.ui) 'dart_flutter.dart';
 
 class _VirtualMachineIO implements PlatformIO {
   @override

--- a/lib/src/text/globalization/culture_io.dart
+++ b/lib/src/text/globalization/culture_io.dart
@@ -6,9 +6,10 @@ import 'dart:async';
 import 'dart:typed_data';
 import 'dart:collection';
 
-import 'package:archive/archive.dart';
 import 'package:time_machine2/src/time_machine_internal.dart';
-import 'package:time_machine2/src/platforms/platform_io.dart';
+
+import 'culture_native_loader.dart'
+    if (dart.library.html) 'culture_web_loader.dart';
 
 @internal
 class CultureLoader {
@@ -18,12 +19,7 @@ class CultureLoader {
     var cultureIds = HashSet<String>();
     var cache = <String, Culture>{Culture.invariantId: Culture.invariant};
 
-    const zipDecoder = GZipDecoder();
-
-    var binary = zipDecoder.decodeBytes(
-        (await PlatformIO.local.getBinary('cultures', 'cultures.bin'))
-            .buffer
-            .asUint8List());
+    final binary = Uint8List.fromList(await getCultureData(''));
 
     var reader = CultureReader(ByteData.view(
       binary.buffer,

--- a/lib/src/text/globalization/culture_native_loader.dart
+++ b/lib/src/text/globalization/culture_native_loader.dart
@@ -1,0 +1,1 @@
+export 'package:time_machine2/data/cultures/cultures.dart';

--- a/lib/src/text/globalization/culture_web_loader.dart
+++ b/lib/src/text/globalization/culture_web_loader.dart
@@ -1,0 +1,15 @@
+import 'dart:typed_data';
+
+import 'package:archive/archive.dart';
+import 'package:time_machine2/src/platforms/platform_io.dart';
+
+Future<List<int>> getCultureData(String path) async {
+  const zipDecoder = GZipDecoder();
+
+  var binary = zipDecoder.decodeBytes(
+      (await PlatformIO.local.getBinary('cultures', 'cultures.bin'))
+          .buffer
+          .asUint8List());
+
+  return binary;
+}


### PR DESCRIPTION
- Culture data is now embedded natively and doesn't require loading a separate asset
- The platform switcher between native Dart and native Flutter should now work as expected

Fix #24 