### PR TITLE
Fix timezone download problem on Flutter Web

### DIFF
--- a/lib/src/platforms/web.dart
+++ b/lib/src/platforms/web.dart
@@ -22,7 +22,7 @@ class _WebMachineIO implements PlatformIO {
 
     try {
       final response = await client.get(
-        Uri.parse('packages/time_machine2/data/$path/$filename'),
+        Uri.parse('assets/packages/time_machine2/data/$path/$filename'),
         headers: {'Accept': 'application/octet-stream'},
       );
 
@@ -46,7 +46,7 @@ class _WebMachineIO implements PlatformIO {
 
     try {
       final response = await client.get(
-        Uri.parse('packages/time_machine2/data/$path/$filename'),
+        Uri.parse('assets/packages/time_machine2/data/$path/$filename'),
         headers: {'Accept': 'application/json'},
       );
 

--- a/lib/src/timezones/tzdb_datetimezone_source_browser_impl.dart
+++ b/lib/src/timezones/tzdb_datetimezone_source_browser_impl.dart
@@ -1,7 +1,3 @@
-// Copyright (c) 2014, the timezone project authors. Please see the AUTHORS
-// file for details. All rights reserved. Use of this source code is governed
-// by a BSD-style license that can be found in the LICENSE file.
-
 import 'package:archive/archive.dart';
 import 'package:time_machine2/src/platforms/platform_io.dart';
 

--- a/lib/src/timezones/tzdb_datetimezone_source_browser_impl.dart
+++ b/lib/src/timezones/tzdb_datetimezone_source_browser_impl.dart
@@ -5,7 +5,7 @@
 import 'package:archive/archive.dart';
 import 'package:time_machine2/src/platforms/platform_io.dart';
 
-Future<List<int>> getTzdbData([String path = 'latest_10y.tzf']) async {
+Future<List<int>> getTzdbData([String path = 'latest_all.tzf']) async {
   final data = await PlatformIO.local.getBinary('tzdb', path);
 
   const zipDecoder = GZipDecoder();


### PR DESCRIPTION
Flutter Web uses a different path scheme for locating assets in release mode. This is a hotfix to address the issue that timezone data cannot be found. The real fix is to rework the `PlatformIO` classes to use `AssetBundle` when using Flutter and new `VirtualIO` implementation for Dart only code.

Fix #33 